### PR TITLE
Support multiple types with the same id in the replication

### DIFF
--- a/cluster/src/main/java/io/blobkeeper/cluster/configuration/ClusterConfiguration.java
+++ b/cluster/src/main/java/io/blobkeeper/cluster/configuration/ClusterConfiguration.java
@@ -19,7 +19,6 @@ package io.blobkeeper.cluster.configuration;
  * limitations under the License.
  */
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton

--- a/cluster/src/main/java/io/blobkeeper/cluster/configuration/ClusterModule.java
+++ b/cluster/src/main/java/io/blobkeeper/cluster/configuration/ClusterModule.java
@@ -1,0 +1,30 @@
+package io.blobkeeper.cluster.configuration;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import io.blobkeeper.cluster.util.ReplicationStatistic;
+import io.blobkeeper.common.configuration.ClassToTypeLiteralMatcherAdapter;
+
+import static com.google.inject.matcher.Matchers.subclassesOf;
+
+public class ClusterModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        install(new JGroupsModule());
+
+        binder().bindListener(new ClassToTypeLiteralMatcherAdapter(subclassesOf(ReplicationStatistic.class)), new TypeListener() {
+            @Override
+            public <I> void hear(TypeLiteral<I> typeLiteral, TypeEncounter<I> typeEncounter) {
+                typeEncounter.register(
+                        (InjectionListener<I>) injectedObject -> {
+                            ReplicationStatistic handler = (ReplicationStatistic) injectedObject;
+                            handler.init();
+                        }
+                );
+            }
+        });
+    }
+}

--- a/cluster/src/main/java/io/blobkeeper/cluster/service/ReplicationClientServiceImpl.java
+++ b/cluster/src/main/java/io/blobkeeper/cluster/service/ReplicationClientServiceImpl.java
@@ -25,6 +25,7 @@ import com.google.common.collect.TreeRangeMap;
 import io.blobkeeper.cluster.configuration.ClusterPropertiesConfiguration;
 import io.blobkeeper.cluster.domain.*;
 import io.blobkeeper.cluster.util.ClusterUtils;
+import io.blobkeeper.cluster.util.ReplicationStatistic;
 import io.blobkeeper.common.util.LeafNode;
 import io.blobkeeper.common.util.MerkleTree;
 import io.blobkeeper.file.domain.File;
@@ -81,6 +82,9 @@ public class ReplicationClientServiceImpl implements ReplicationClientService {
     @Inject
     private PartitionService partitionService;
 
+    @Inject
+    private ReplicationStatistic replicationStatistic;
+
     @Override
     public void replicate(@NotNull ReplicationFile file) {
         if (log.isTraceEnabled()) {
@@ -112,6 +116,8 @@ public class ReplicationClientServiceImpl implements ReplicationClientService {
         } catch (Exception e) {
             log.error("Can't replicate file", e);
             throw new ReplicationServiceException(e);
+        } finally {
+            replicationStatistic.onReplicationElt();
         }
     }
 
@@ -124,6 +130,7 @@ public class ReplicationClientServiceImpl implements ReplicationClientService {
             return;
         }
 
+        // TODO: calculate what types are different instead whole range
         RangeMap<Long, LeafNode> nodes = TreeRangeMap.create();
 
         differenceInfo.getDifference().stream()

--- a/cluster/src/main/java/io/blobkeeper/cluster/util/ClusterUtils.java
+++ b/cluster/src/main/java/io/blobkeeper/cluster/util/ClusterUtils.java
@@ -19,10 +19,8 @@ package io.blobkeeper.cluster.util;
  * limitations under the License.
  */
 
-import io.blobkeeper.cluster.domain.CustomMessageHeader;
 import io.blobkeeper.cluster.domain.MerkleTreeInfo;
 import io.blobkeeper.file.service.PartitionService;
-import io.blobkeeper.index.domain.CacheKey;
 import io.blobkeeper.index.domain.Partition;
 import org.jetbrains.annotations.NotNull;
 import org.jgroups.Address;
@@ -37,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.blobkeeper.cluster.domain.Command.CACHE_INVALIDATE_REQUEST;
 import static io.blobkeeper.cluster.domain.CustomMessageHeader.CUSTOM_MESSAGE_HEADER;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;

--- a/cluster/src/main/java/io/blobkeeper/cluster/util/ReplicationStatistic.java
+++ b/cluster/src/main/java/io/blobkeeper/cluster/util/ReplicationStatistic.java
@@ -1,7 +1,7 @@
-package io.blobkeeper.cluster.configuration;
+package io.blobkeeper.cluster.util;
 
 /*
- * Copyright (C) 2015 by Denis M. Gabaydulin
+ * Copyright (C) 2016 by Denis M. Gabaydulin
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,21 +19,28 @@ package io.blobkeeper.cluster.configuration;
  * limitations under the License.
  */
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import org.jgroups.blocks.locking.LockService;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
-public class JGroupsModule extends AbstractModule {
+@Singleton
+public class ReplicationStatistic {
+    private static final Logger log = LoggerFactory.getLogger(ReplicationStatistic.class);
 
-    @Override
-    protected void configure() {
+    private static final String REPLICATION_ELEMENTS = "blobkeeper.replication.elements";
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    public void init() {
+        metricRegistry.register(REPLICATION_ELEMENTS, new Counter());
     }
 
-    @Provides
-    @Singleton
-    LockService lockService() {
-        return new LockService();
+    public void onReplicationElt() {
+        metricRegistry.getCounters().get(REPLICATION_ELEMENTS).inc();
     }
 }

--- a/cluster/src/test/java/io/blobkeeper/cluster/service/CompactionServiceTest.java
+++ b/cluster/src/test/java/io/blobkeeper/cluster/service/CompactionServiceTest.java
@@ -22,6 +22,7 @@ package io.blobkeeper.cluster.service;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.service.IdGeneratorService;
 import io.blobkeeper.common.util.MerkleTree;
@@ -61,7 +62,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 
-@Guice(modules = {RootModule.class})
+@Guice(modules = {RootModule.class, MetricModule.class})
 public class CompactionServiceTest extends BaseFileTest {
     private static final Logger log = LoggerFactory.getLogger(CompactionServiceTest.class);
 

--- a/cluster/src/test/java/io/blobkeeper/cluster/service/RepairServiceTest.java
+++ b/cluster/src/test/java/io/blobkeeper/cluster/service/RepairServiceTest.java
@@ -24,8 +24,10 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.blobkeeper.cluster.domain.*;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.util.Block;
+import io.blobkeeper.common.util.BlockElt;
 import io.blobkeeper.common.util.MerkleTree;
 import io.blobkeeper.common.util.Utils;
 import io.blobkeeper.file.service.DiskService;
@@ -52,6 +54,8 @@ import org.testng.annotations.Test;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import java.util.Arrays;
+
 import static com.google.common.collect.Range.closedOpen;
 import static java.lang.Thread.sleep;
 import static org.mockito.Matchers.any;
@@ -62,7 +66,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@Guice(modules = {RootModule.class, RepairServiceTest.Mocks.class})
+@Guice(modules = {RootModule.class, RepairServiceTest.Mocks.class, MetricModule.class})
 public class RepairServiceTest {
     private static final Logger log = LoggerFactory.getLogger(RepairServiceTest.class);
 
@@ -154,7 +158,7 @@ public class RepairServiceTest {
         MerkleTree masterTree = Utils.createTree(
                 closedOpen(0L, 100L),
                 32,
-                ImmutableSortedMap.of(42L, new Block(1L, 2L, 3L, 4L))
+                ImmutableSortedMap.of(42L, new Block(1L, Arrays.asList(new BlockElt(1, 0, 2, 3, 4))))
         );
 
         MerkleTreeInfo masterInfo = new MerkleTreeInfo();

--- a/cluster/src/test/java/io/blobkeeper/cluster/service/ReplicationClientServiceTest.java
+++ b/cluster/src/test/java/io/blobkeeper/cluster/service/ReplicationClientServiceTest.java
@@ -28,8 +28,10 @@ import io.blobkeeper.cluster.domain.DifferenceInfo;
 import io.blobkeeper.cluster.domain.MerkleTreeInfo;
 import io.blobkeeper.cluster.domain.Node;
 import io.blobkeeper.cluster.domain.Role;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.util.Block;
+import io.blobkeeper.common.util.BlockElt;
 import io.blobkeeper.common.util.MerkleTree;
 import io.blobkeeper.common.util.Utils;
 import io.blobkeeper.file.domain.File;
@@ -57,6 +59,7 @@ import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Arrays;
 
 import static com.google.common.collect.Range.closedOpen;
 import static java.lang.Thread.sleep;
@@ -65,7 +68,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@Guice(modules = {RootModule.class, ReplicationClientServiceTest.Mocks.class})
+@Guice(modules = {RootModule.class, ReplicationClientServiceTest.Mocks.class, MetricModule.class})
 public class ReplicationClientServiceTest {
     private static final Logger log = LoggerFactory.getLogger(ReplicationClientServiceTest.class);
 
@@ -129,7 +132,7 @@ public class ReplicationClientServiceTest {
         MerkleTree masterTree = Utils.createTree(
                 closedOpen(0L, 100L),
                 32,
-                ImmutableSortedMap.of(42L, new Block(1L, 2L, 3L, 4L))
+                ImmutableSortedMap.of(42L, new Block(1L, Arrays.asList(new BlockElt(1, 0, 2, 3, 4))))
         );
 
         MerkleTreeInfo masterInfo = new MerkleTreeInfo();

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,6 +17,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.3.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.1.2</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/common/src/main/java/io/blobkeeper/common/configuration/MetricModule.java
+++ b/common/src/main/java/io/blobkeeper/common/configuration/MetricModule.java
@@ -1,7 +1,7 @@
-package io.blobkeeper.cluster.configuration;
+package io.blobkeeper.common.configuration;
 
 /*
- * Copyright (C) 2015 by Denis M. Gabaydulin
+ * Copyright (C) 2016 by Denis M. Gabaydulin
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,21 +19,33 @@ package io.blobkeeper.cluster.configuration;
  * limitations under the License.
  */
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import org.jgroups.blocks.locking.LockService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
+import java.util.concurrent.TimeUnit;
 
-public class JGroupsModule extends AbstractModule {
+public class MetricModule extends AbstractModule {
+    private static final Logger metricsLogger = LoggerFactory.getLogger("metrics");
 
     @Override
     protected void configure() {
+        // FIXME: add configuration parameter
+        Slf4jReporter
+                .forRegistry(createMetricRegistry())
+                .outputTo(metricsLogger)
+                .build()
+                .start(30, TimeUnit.SECONDS);
     }
 
     @Provides
     @Singleton
-    LockService lockService() {
-        return new LockService();
+    MetricRegistry createMetricRegistry() {
+        return new MetricRegistry();
     }
 }
+

--- a/common/src/main/java/io/blobkeeper/common/util/BlockElt.java
+++ b/common/src/main/java/io/blobkeeper/common/util/BlockElt.java
@@ -1,0 +1,71 @@
+package io.blobkeeper.common.util;
+
+import com.google.common.base.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * @author Denis Gabaydulin
+ * @since 17/05/2016
+ */
+public class BlockElt {
+    private final long id;
+    private final int type;
+    private final long offset;
+    private final long length;
+    private final long crc;
+
+    public BlockElt(long id, int type, long offset, long length, long crc) {
+        this.id = id;
+        this.type = type;
+        this.offset = offset;
+        this.length = length;
+        this.crc = crc;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public long getCrc() {
+        return crc;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BlockElt that = (BlockElt) o;
+
+        return Objects.equal(this.id, that.id) && Objects.equal(this.type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, type);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("id", id)
+                .add("type", type)
+                .add("offset", offset)
+                .add("length", length)
+                .add("crc", crc)
+                .toString();
+    }
+}

--- a/common/src/main/java/io/blobkeeper/common/util/BlockEltComparator.java
+++ b/common/src/main/java/io/blobkeeper/common/util/BlockEltComparator.java
@@ -1,7 +1,7 @@
-package io.blobkeeper.cluster.configuration;
+package io.blobkeeper.common.util;
 
 /*
- * Copyright (C) 2015 by Denis M. Gabaydulin
+ * Copyright (C) 2016 by Denis M. Gabaydulin
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,21 +19,13 @@ package io.blobkeeper.cluster.configuration;
  * limitations under the License.
  */
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import org.jgroups.blocks.locking.LockService;
+import java.util.Comparator;
 
-import javax.inject.Singleton;
-
-public class JGroupsModule extends AbstractModule {
-
+public class BlockEltComparator implements Comparator<BlockElt> {
     @Override
-    protected void configure() {
-    }
-
-    @Provides
-    @Singleton
-    LockService lockService() {
-        return new LockService();
+    public int compare(BlockElt one, BlockElt two) {
+        return Comparator.comparingLong(BlockElt::getId)
+                .thenComparing(BlockElt::getType)
+                .compare(one, two);
     }
 }

--- a/common/src/main/java/io/blobkeeper/common/util/GuavaCollectors.java
+++ b/common/src/main/java/io/blobkeeper/common/util/GuavaCollectors.java
@@ -20,8 +20,11 @@ package io.blobkeeper.common.util;
  */
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 
+import java.util.Comparator;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -46,6 +49,18 @@ public class GuavaCollectors {
         BiConsumer<ImmutableSet.Builder<T>, T> accumulator = (b, v) -> b.add(v);
         BinaryOperator<ImmutableSet.Builder<T>> combiner = (l, r) -> l.addAll(r.build());
         Function<ImmutableSet.Builder<T>, ImmutableSet<T>> finisher = ImmutableSet.Builder::build;
+
+        return Collector.of(supplier, accumulator, combiner, finisher);
+    }
+
+    public static <T, K, V> Collector<T, ?, ImmutableMap<K, V>> toImmutableMap(
+            Function<? super T, ? extends K> keyMapper,
+            Function<? super T, ? extends V> valueMapper
+    ) {
+        Supplier<ImmutableMap.Builder<K, V>> supplier = ImmutableMap.Builder::new;
+        BiConsumer<ImmutableMap.Builder<K, V>, T> accumulator = (b, t) -> b.put(keyMapper.apply(t), valueMapper.apply(t));
+        BinaryOperator<ImmutableMap.Builder<K, V>> combiner = (l, r) -> l.putAll(r.build());
+        Function<ImmutableMap.Builder<K, V>, ImmutableMap<K, V>> finisher = ImmutableMap.Builder::build;
 
         return Collector.of(supplier, accumulator, combiner, finisher);
     }

--- a/common/src/main/java/io/blobkeeper/common/util/MerkleTree.java
+++ b/common/src/main/java/io/blobkeeper/common/util/MerkleTree.java
@@ -101,7 +101,8 @@ public class MerkleTree implements Serializable {
             }
 
             if (current != null) {
-                current.addHash(Longs.toByteArray(block.getId()), block.getLength());
+                // FIXME
+                current.addHash(block.toByteArray(), block.getLength());
             } else {
                 break;
             }

--- a/common/src/main/java/io/blobkeeper/common/util/Utils.java
+++ b/common/src/main/java/io/blobkeeper/common/util/Utils.java
@@ -37,8 +37,10 @@ public class Utils {
      * longer input, but if either input is null, the output will be null.
      */
     public static byte[] xor(byte[] left, byte[] right) {
-        if (left == null || right == null)
+        if (left == null || right == null) {
             return null;
+        }
+
         if (left.length > right.length) {
             byte[] swap = left;
             left = right;
@@ -62,8 +64,7 @@ public class Utils {
         if (l.compareTo(r) < 0) {
             BigInteger sum = l.add(r);
             midPoint = sum.shiftRight(1);
-        } else // wrapping case
-        {
+        } else { // wrapping case
             BigInteger max = BigInteger.valueOf(Long.MAX_VALUE);
             BigInteger min = BigInteger.valueOf(Long.MIN_VALUE);
             // length of range we're bisecting is (R - min) + (max - L)

--- a/common/src/test/java/io/blobkeeper/common/util/BlockTest.java
+++ b/common/src/test/java/io/blobkeeper/common/util/BlockTest.java
@@ -1,7 +1,7 @@
-package io.blobkeeper.cluster.configuration;
+package io.blobkeeper.common.util;
 
 /*
- * Copyright (C) 2015 by Denis M. Gabaydulin
+ * Copyright (C) 2016 by Denis M. Gabaydulin
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,21 +19,26 @@ package io.blobkeeper.cluster.configuration;
  * limitations under the License.
  */
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import org.jgroups.blocks.locking.LockService;
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
 
-import javax.inject.Singleton;
+import static org.testng.AssertJUnit.assertEquals;
 
-public class JGroupsModule extends AbstractModule {
+public class BlockTest {
+    private static final Logger log = LoggerFactory.getLogger(BlockTest.class);
 
-    @Override
-    protected void configure() {
-    }
+    @Test
+    public void toByteArray() {
+        Block block = new Block(
+                303274580351389722L,
+                ImmutableList.of(
+                        new BlockElt(303274580351389722L, 0, 0, 128, 128L),
+                        new BlockElt(303274580351389722L, 1, 128, 128, 128L)
+                )
+        );
 
-    @Provides
-    @Singleton
-    LockService lockService() {
-        return new LockService();
+        assertEquals(block.toByteArray(), new byte[]{4, 53, 114, -97, -65, 64, 16, 26, 0, 0, 0, 0, 0, 0, 0, 1});
     }
 }

--- a/file/src/test/java/io/blobkeeper/file/service/FileListServiceTest.java
+++ b/file/src/test/java/io/blobkeeper/file/service/FileListServiceTest.java
@@ -22,6 +22,7 @@ package io.blobkeeper.file.service;
 import com.google.common.io.Files;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.file.domain.File;
 import io.blobkeeper.index.dao.IndexDao;
@@ -44,7 +45,7 @@ import static java.util.Collections.sort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Guice(modules = {RootModule.class, FileListServiceTest.Mocks.class})
+@Guice(modules = {RootModule.class, FileListServiceTest.Mocks.class, MetricModule.class})
 public class FileListServiceTest extends BaseFileTest {
     private static final Logger log = LoggerFactory.getLogger(FileListServiceTest.class);
 

--- a/file/src/test/java/io/blobkeeper/file/service/FileStorageTest.java
+++ b/file/src/test/java/io/blobkeeper/file/service/FileStorageTest.java
@@ -21,6 +21,7 @@ package io.blobkeeper.file.service;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.service.IdGeneratorService;
 import io.blobkeeper.file.configuration.FileConfiguration;
@@ -42,7 +43,7 @@ import javax.inject.Inject;
 import static io.blobkeeper.file.util.FileUtils.readFileToString;
 import static org.testng.AssertJUnit.assertEquals;
 
-@Guice(modules = {RootModule.class})
+@Guice(modules = {RootModule.class, MetricModule.class})
 public class FileStorageTest extends BaseFileTest {
 
     @Inject

--- a/file/src/test/java/io/blobkeeper/file/util/FileUtilsTest.java
+++ b/file/src/test/java/io/blobkeeper/file/util/FileUtilsTest.java
@@ -23,6 +23,7 @@ import com.datastax.driver.core.utils.Bytes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 import com.google.common.io.Files;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.util.MerkleTree;
 import io.blobkeeper.file.configuration.FileConfiguration;
@@ -49,7 +50,7 @@ import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertEquals;
 
-@Guice(modules = {RootModule.class})
+@Guice(modules = {RootModule.class, MetricModule.class})
 public class FileUtilsTest extends BaseFileTest {
 
     @Inject
@@ -97,7 +98,7 @@ public class FileUtilsTest extends BaseFileTest {
 
         MerkleTree tree = FileUtils.buildMerkleTree(indexService, file, new Partition(0, 0));
         assertEquals(tree.getLeafNodes().get(0).getRange(), Range.openClosed(214803434770010111L, 214803434770010112L));
-        assertEquals(tree.getLeafNodes().get(0).getHash(), new byte[]{2, -5, 34, -107, -6, 0, 16, 0});
+        assertEquals(tree.getLeafNodes().get(0).getHash(), new byte[]{2, -5, 34, -107, -6, 0, 16, 0, 0, 0, 0, 1});
 
         file.close();
     }

--- a/index/src/main/java/io/blobkeeper/index/domain/IndexElt.java
+++ b/index/src/main/java/io/blobkeeper/index/domain/IndexElt.java
@@ -23,6 +23,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import io.blobkeeper.common.util.BlockElt;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
@@ -177,6 +178,11 @@ public class IndexElt implements Serializable {
     @NotNull
     public CacheKey toCacheKey() {
         return new CacheKey(id, type);
+    }
+
+    @NotNull
+    public BlockElt toBlockElt() {
+        return new BlockElt(id, type, getOffset(), getLength(), crc);
     }
 
     private List<String> getAuthTokens() {

--- a/index/src/test/java/io/blobkeeper/index/dao/IndexDaoTest.java
+++ b/index/src/test/java/io/blobkeeper/index/dao/IndexDaoTest.java
@@ -21,6 +21,7 @@ package io.blobkeeper.index.dao;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.service.IdGeneratorService;
 import io.blobkeeper.index.configuration.IndexConfiguration;
@@ -41,7 +42,7 @@ import static org.joda.time.DateTime.now;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.*;
 
-@Guice(modules = RootModule.class)
+@Guice(modules = {RootModule.class, MetricModule.class})
 public class IndexDaoTest {
 
     @Inject

--- a/index/src/test/java/io/blobkeeper/index/dao/PartitionDaoTest.java
+++ b/index/src/test/java/io/blobkeeper/index/dao/PartitionDaoTest.java
@@ -22,7 +22,10 @@ package io.blobkeeper.index.dao;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Longs;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
+import io.blobkeeper.common.util.Block;
+import io.blobkeeper.common.util.BlockElt;
 import io.blobkeeper.common.util.LeafNode;
 import io.blobkeeper.common.util.MerkleTree;
 import io.blobkeeper.index.domain.IndexElt;
@@ -35,11 +38,13 @@ import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 
+import java.util.Arrays;
+
 import static com.google.common.collect.ImmutableList.of;
 import static org.testng.Assert.*;
 import static org.testng.Assert.assertEquals;
 
-@Guice(modules = RootModule.class)
+@Guice(modules = {RootModule.class, MetricModule.class})
 public class PartitionDaoTest {
 
     @Inject
@@ -152,7 +157,18 @@ public class PartitionDaoTest {
 
         assertEquals(node.getRange(), Range.openClosed(indexElt.getId() - 1, indexElt.getId()));
         assertEquals(node.getBlocks(), 1);
-        assertEquals(node.getHash(), Longs.toByteArray(indexElt.getId()));
+
+        Block block = new Block(indexElt.getId(), Arrays.asList(
+                new BlockElt(
+                        indexElt.getId(),
+                        indexElt.getType(),
+                        indexElt.getOffset(),
+                        indexElt.getLength(),
+                        indexElt.getCrc()
+                )
+        ));
+
+        assertEquals(node.getHash(), block.toByteArray());
         assertEquals(node.getLength(), indexElt.getLength());
     }
 
@@ -171,7 +187,18 @@ public class PartitionDaoTest {
 
         assertEquals(node.getRange(), Range.openClosed(indexElt.getId() - 1, indexElt.getId()));
         assertEquals(node.getBlocks(), 1);
-        assertEquals(node.getHash(), Longs.toByteArray(indexElt.getId()));
+
+        Block block = new Block(indexElt.getId(), Arrays.asList(
+                new BlockElt(
+                        indexElt.getId(),
+                        indexElt.getType(),
+                        indexElt.getOffset(),
+                        indexElt.getLength(),
+                        indexElt.getCrc()
+                )
+        ));
+
+        assertEquals(node.getHash(), block.toByteArray());
         assertEquals(node.getLength(), indexElt.getLength());
     }
 

--- a/server/src/main/java/io/blobkeeper/server/BlobKeeperServerApp.java
+++ b/server/src/main/java/io/blobkeeper/server/BlobKeeperServerApp.java
@@ -21,7 +21,9 @@ package io.blobkeeper.server;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
+import io.blobkeeper.server.configuration.ServerModule;
 import org.apache.commons.daemon.Daemon;
 import org.apache.commons.daemon.DaemonContext;
 import org.apache.commons.daemon.DaemonInitException;
@@ -47,7 +49,7 @@ public class BlobKeeperServerApp implements Daemon {
     @Override
     public synchronized void start() throws Exception {
         try {
-            Injector injector = Guice.createInjector(new RootModule());
+            Injector injector = Guice.createInjector(new RootModule(), new ServerModule(), new MetricModule());
             server = injector.getInstance(BlobKeeperServer.class);
             server.startAsync();
             server.awaitRunning();

--- a/server/src/main/java/io/blobkeeper/server/configuration/ServerModule.java
+++ b/server/src/main/java/io/blobkeeper/server/configuration/ServerModule.java
@@ -25,6 +25,7 @@ import com.google.inject.matcher.Matchers;
 import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
+import io.blobkeeper.cluster.configuration.ClusterModule;
 import io.blobkeeper.common.configuration.ClassToTypeLiteralMatcherAdapter;
 import io.blobkeeper.server.handler.FileWriterHandler;
 
@@ -33,6 +34,8 @@ import static com.google.inject.matcher.Matchers.subclassesOf;
 public class ServerModule extends AbstractModule {
     @Override
     protected void configure() {
+        install(new ClusterModule());
+
         binder().bindListener(new ClassToTypeLiteralMatcherAdapter(subclassesOf(FileWriterHandler.class)), new TypeListener() {
             @Override
             public <I> void hear(TypeLiteral<I> typeLiteral, TypeEncounter<I> typeEncounter) {

--- a/server/src/test/java/io/blobkeeper/server/BasicOperationTest.java
+++ b/server/src/test/java/io/blobkeeper/server/BasicOperationTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import io.blobkeeper.client.service.BlobKeeperClient;
 import io.blobkeeper.client.service.BlobKeeperClientImpl;
 import io.blobkeeper.client.util.BlobKeeperClientUtils;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.domain.Result;
 import io.blobkeeper.common.domain.api.EmptyRequest;
@@ -59,11 +60,12 @@ import java.io.IOException;
 
 import static com.google.common.io.Files.write;
 import static io.blobkeeper.file.util.FileUtils.getDiskPathByDisk;
+import static io.blobkeeper.server.TestUtils.assertResponseOk;
 import static java.io.File.createTempFile;
 import static java.nio.charset.Charset.forName;
 import static org.testng.Assert.*;
 
-@Guice(modules = {RootModule.class, ServerModule.class})
+@Guice(modules = {RootModule.class, ServerModule.class, MetricModule.class})
 public class BasicOperationTest {
     private static final Logger log = LoggerFactory.getLogger(BasicOperationTest.class);
 
@@ -113,9 +115,7 @@ public class BasicOperationTest {
 
         // send get query
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         // send post query
         postResponse = client.addFile(file, ImmutableMap.of("X-Metadata-Content-Type", "text/plain"));
@@ -128,9 +128,7 @@ public class BasicOperationTest {
 
         // send get query
         getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         // send delete query
         Response deleteResponse = client.deleteFile(givenId, serverConfiguration.getApiToken());
@@ -178,9 +176,7 @@ public class BasicOperationTest {
 
         // send get query
         getResponse = client.getFile(result.getIdLong(), 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
     }
 
     @Test
@@ -210,9 +206,7 @@ public class BasicOperationTest {
         long givenId = result.getIdLong();
 
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
     }
 
     @Test
@@ -239,14 +233,10 @@ public class BasicOperationTest {
         assertEquals(getResponse.getStatusCode(), 403);
 
         getResponse = client.getFile(givenId, 0, token1);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         getResponse = client.getFile(givenId, 0, token2);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         getResponse = client.getFile(givenId, 0, TokenUtils.getToken(serverConfiguration.getSecretToken(), 42L));
         assertEquals(getResponse.getStatusCode(), 403);
@@ -291,9 +281,7 @@ public class BasicOperationTest {
         long givenId = result.getIdLong();
 
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         String value = getResponse.getHeader("last-modified");
         assertNotNull(value);
@@ -335,9 +323,7 @@ public class BasicOperationTest {
         long givenId = result.getIdLong();
 
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         String value = getResponse.getHeader("last-modified");
         assertNotNull(value);
@@ -376,9 +362,7 @@ public class BasicOperationTest {
                 .execute()
                 .get();
 
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
     }
 
     @Test
@@ -396,9 +380,7 @@ public class BasicOperationTest {
         long givenId = result.getIdLong();
 
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         getResponse = client.getFile(givenId, 1);
         assertEquals(getResponse.getStatusCode(), 404);
@@ -409,9 +391,7 @@ public class BasicOperationTest {
         assertTrue(postResponse.getResponseBody().contains("\"result\":{\"id\""));
 
         getResponse = client.getFile(givenId, 1);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
     }
 
     @Test
@@ -429,9 +409,7 @@ public class BasicOperationTest {
         long givenId = result.getIdLong();
 
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         getResponse = client.getFile(givenId, 1);
         assertEquals(getResponse.getStatusCode(), 404);
@@ -442,9 +420,7 @@ public class BasicOperationTest {
         assertTrue(postResponse.getResponseBody().contains("\"result\":{\"id\""));
 
         getResponse = client.getFile(givenId, 1);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "test");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "test", "text/plain");
 
         postResponse = client.addFile(givenId, 1, file, ImmutableMap.of("X-Metadata-Content-Type", "text/plain"));
         assertEquals(postResponse.getStatusCode(), 409);
@@ -481,9 +457,7 @@ public class BasicOperationTest {
 
         // check saved file
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "testtest");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "testtest", "text/plain");
 
         // delete it
         Response deleteResponse = client.deleteFile(givenId, serverConfiguration.getApiToken());
@@ -511,9 +485,7 @@ public class BasicOperationTest {
 
         // check saved file
         Response getResponse = client.getFile(givenId, 0);
-        assertEquals(getResponse.getStatusCode(), 200);
-        assertEquals(getResponse.getResponseBody(), "testtest");
-        assertEquals(getResponse.getContentType(), "text/plain");
+        assertResponseOk(getResponse, "testtest", "text/plain");
 
         // invalid token
         Response deleteResponse = client.deleteFile(givenId, "");

--- a/server/src/test/java/io/blobkeeper/server/TestUtils.java
+++ b/server/src/test/java/io/blobkeeper/server/TestUtils.java
@@ -1,0 +1,25 @@
+package io.blobkeeper.server;
+
+import org.asynchttpclient.Response;
+import org.jetbrains.annotations.NotNull;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Denis Gabaydulin
+ * @since 18.05.16
+ */
+public class TestUtils {
+    private TestUtils() {
+    }
+
+    public static void assertResponseOk(
+            @NotNull Response response,
+            @NotNull String expectedBody,
+            @NotNull String expectedContentType
+    ) {
+        assertEquals(response.getStatusCode(), 200);
+        assertEquals(response.getResponseBody(), expectedBody);
+        assertEquals(response.getContentType(), expectedContentType);
+    }
+}

--- a/server/src/test/java/io/blobkeeper/server/service/FileWriterServiceTest.java
+++ b/server/src/test/java/io/blobkeeper/server/service/FileWriterServiceTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.blobkeeper.cluster.service.ClusterMembershipService;
+import io.blobkeeper.common.configuration.MetricModule;
 import io.blobkeeper.common.configuration.RootModule;
 import io.blobkeeper.common.service.IdGeneratorService;
 import io.blobkeeper.file.configuration.FileConfiguration;
@@ -56,7 +57,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Guice(modules = {RootModule.class, FileWriterServiceTest.Mocks.class})
+@Guice(modules = {RootModule.class, FileWriterServiceTest.Mocks.class, MetricModule.class})
 public class FileWriterServiceTest extends BaseFileTest {
     private static final Logger log = LoggerFactory.getLogger(FileWriterServiceTest.class);
 


### PR DESCRIPTION
Merkle tree replication must support multiple types with the same id. Types represent thumbs of a original file.

A block has id and a list of elements (types). The merkle tree operates ranges of original id, but the hash of a leaf node includes all types of the orignal id (in the given partition). So, even if, the set of original elements are identical, but types are different, hashes will be different as well.
